### PR TITLE
cfree has been removed from glibc 2.26

### DIFF
--- a/src/Ylib/okmalloc.c
+++ b/src/Ylib/okmalloc.c
@@ -901,7 +901,7 @@ VOIDPTR ptr;
 VOID Ysafe_cfree(ptr)
 VOIDPTR ptr;
 {
-    cfree(ptr);
+    free(ptr);
     return;
 }
 


### PR DESCRIPTION
It's recommended to use `free` instead