### PR TITLE
Use free instead of cfree.

### DIFF
--- a/src/Ylib/okmalloc.c
+++ b/src/Ylib/okmalloc.c
@@ -901,7 +901,7 @@ VOIDPTR ptr;
 VOID Ysafe_cfree(ptr)
 VOIDPTR ptr;
 {
-    cfree(ptr);
+    free(ptr);
     return;
 }
 


### PR DESCRIPTION
man cfree says:

This function should never be used.  Use free(3) instead.  Starting with version 2.26, it has been removed from glibc.

And thus this breaks the build in Ubuntu 17.10.

Fix #16